### PR TITLE
Updated docker building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,3 +63,5 @@ typings/
 
 dist
 .mongo
+# git folder for git repository to be not included in the docker build
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,30 @@
-FROM node:16-alpine3.16
+# multi-stage docker-build for building the typescript project
+FROM node:16-alpine3.16 AS builder
 
-ENV PRODUCTION=true
+WORKDIR /build
 
-WORKDIR /app
 COPY . .
 
 RUN yarn install
 RUN yarn build
+
+# main docker
+FROM node:16-alpine3.16
+
+ENV PRODUCTION=true
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+# copy package files
+COPY --from=builder /build/package.json /app/package.json
+COPY --from=builder /build/yarn.lock /app/yarn.lock
+
+# install ONLY production dependencies
+RUN yarn install --frozen-lockfile --prod && yarn cache clean
+
+# copy compiled files from previous docker-build-stage
+COPY --from=builder /build/dist /app/dist
 
 EXPOSE 3000
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "mongoose": "^6.6.5",
     "openapi3-ts": "^3.1.1",
     "reflect-metadata": "^0.1.13",
-    "typescript": "^4.8.4",
     "ua-parser-js": "^1.0.2"
   },
   "devDependencies": {
@@ -46,6 +45,7 @@
     "@types/swagger-schema-official": "^2.0.22",
     "@types/ua-parser-js": "^0.7.36",
     "jest": "^29.1.2",
+    "typescript": "^4.8.4",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"


### PR DESCRIPTION
## Changes
- Added .git to .dockerignore because the folder is not needed for building the docker
- Updated the Dockerfile with a multi-stage build job
  - In the first stage the typescript project is built
  - In the second stage only the project dependencies are installed and the built files are copied from the first stage
  - Goal: reducing the size of the final docker image by ~2.5x
- Typescript is moved to a devDependency, because there is no reason for it to be a normal project dependency