### PR TITLE
- fix response schema for /packages/currentPackageCost

### DIFF
--- a/src/cards/routes.ts
+++ b/src/cards/routes.ts
@@ -125,7 +125,7 @@ export default async function routes(fastify) {
     schema: {
       tags: ["Cards"],
       response: {
-        200: { $ref: "BuyDefaultPackageSchemaResponse" },
+        200: { $ref: "CurrentPackageCostResponse" },
       },
     },
     handler: CardPackController.currentPackageCost,


### PR DESCRIPTION
-  The route /packages/currentPackageCost returns the wrong response schema. It should be CurrentPackageCostResponse